### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,17 @@ docker-compose exec backend python manage.py createsuperuser
 7. The admin panel is available [http://0.0.0.0:8080/admin](http://0.0.0.0:8080/admin)
 
 8. The application works in development mode (max 2 products & 5 users/persons).
-Set license value in `LICENSE_TRIAL_KEY` variable and run the `python manage.py create_trial_license` command to create a trial license.
+The server needs two license files to be present before you can run it. You can find the developer license files in the repository. They are `developer.license` and `developer.license_key.pub`. You need to point to these two files in the `.env` file. Corresponding env variable names are `LICENSE_FILE` and `LICENSE_PUB_KEY`. After you make the changes, the last two lines of your `.env` file should be like this:
+```
+LICENSE_FILE=developer.license
+LICENSE_PUB_KEY=developer.license_key.pub
+```
 
-
+The server needs two license files to be present before you can run it. You can find the developer license files in the repository. They are `developer.license` and `developer.license_key.pub`. You need to point to these two files in the `.env` file. Corresponding env variable names are `LICENSE_FILE` and `LICENSE_PUB_KEY`. After you make the changes, the last two lines of your `.env` file should be like this:
+```
+LICENSE_FILE=developer.license
+LICENSE_PUB_KEY=developer.license_key.pub
+```
 if after starting the project in the console the error is: "Invalid HTTP_HOST header: 'localhost:8000'. You may need to add 'localhost' to ALLOWED_HOSTS", and frontend crashes after first render.
 1. Create a local_settings.py under product-factory-composer/backend/backend folder.
 2. Add the following codes.


### PR DESCRIPTION
The subcommand `create_trial_license` is no longer available.
License files are now available for developers in the backend repository.